### PR TITLE
Use BUILD_DSL_SCRIPTS instead of JOB_DSL_PATH.

### DIFF
--- a/seed-job/README.md
+++ b/seed-job/README.md
@@ -3,17 +3,17 @@
 This script will initialize your first seed job and execute it.
 It currently requires following parameters (environment variables)
 
-- `SEED_JOBS_REPO` : Required. GIT url.
-- `GIT_PASSWORD`   : Optional. Password required to access the GIT repo.
-- `GIT_USERNAME`   : Optional. Username required to acces the GIT repo.
-- `JOB_DSL_PATH`   : Optional. Job DSL path containing groovy code to generate/maintain your jobs. By default, it is set to `jobs_dsl/**`
+- `SEED_JOBS_REPO`    : Required. GIT url.
+- `GIT_PASSWORD`      : Optional. Password required to access the GIT repo.
+- `GIT_USERNAME`      : Optional. Username required to acces the GIT repo.
+- `BUILD_DSL_SCRIPTS` : Optional. Job DSL collection of groovy scripts to generate/maintain your jobs. By default, it is set to `jobs_dsl/**/*.groovy`
 
 It has been designed to do the following:
 
 1. create Freestyle project, called 'seed-job'.
 2. Create the credential if GIT\_USERNAME & GIT\_PASSWORD are set. The credential ID will be 'github'.
-3. Attach the SCM to the seed-job with the SEED\_JOBS\_REPO and evantually attach the credential created.
-4. Configure job-dsl to read all DSL from  `jobs-dsl/**/*.groovy`, or from `JOB_DSL_PATH`
+3. Attach the SCM to the seed-job with the SEED\_JOBS\_REPO and eventually attach the credential created.
+4. Configure job-dsl to read all DSL from  `jobs-dsl/**/*.groovy`, or from `BUILD_DSL_SCRIPTS`
 5. Run the seed-job
 
 **NOTE**:
@@ -22,11 +22,11 @@ If you need to re-use the created/updated credential used by the seedjob in your
 
 Ex:
 
-    Job('project_pull_request') {
+    Job('vnfm_pull_request') {
        scm {
           git {
              remote {
-                url('https://github.com/project/manager')
+                url('https://github.hpe.com/vnfm/manager')
                 credentials('github') # Use the credential ID 'github' created/maintained by seed-job.groovy
              }
           }

--- a/seed-job/seed-job.desc
+++ b/seed-job/seed-job.desc
@@ -1,2 +1,1 @@
-plugin:job-dsl:1.45
 groovy:seed-job


### PR DESCRIPTION
This way, we can name files with other extension than `.groovy`, used originally.