### PR TITLE
Avoid duplicate cloud based on the cloud name

### DIFF
--- a/ec2/ec2.groovy
+++ b/ec2/ec2.groovy
@@ -181,6 +181,10 @@ try {
         AmazonEC2Cloud amazonEC2Cloud = createAmazonEC2Cloud(config[i], (List<? extends SlaveTemplate>) templates)
 
         // add cloud configuration to Jenkins
+        if ( jenkins.clouds.getByName(config[i].cloudName) ) {
+          jenkins.clouds.remove(cloudList.getByName(config[i].cloudName))
+        }
+
         jenkins.clouds.add(amazonEC2Cloud)
         break;
       default: break


### PR DESCRIPTION
The logic is to delete the cloud with the same name before create the new one.